### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/http/local.settings.json
+++ b/http/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with Azurite emulator settings for local development. Matches sibling repo `functions-quickstart-dotnet-azd`.

## What's included

`http/local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: dotnet-isolated`

## Context

Tracked by Azure/azure-functions-templates#TRACKING_ISSUE — ensuring all manifest templates have `local.settings.json` for local development per review feedback.
