### PR TITLE
Migrate sample to Azure Functions SDK

### DIFF
--- a/http/http.csproj
+++ b/http/http.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Azure.Functions.Sdk/0.5.0">
+﻿<Project Sdk="Azure.Functions.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/http/http.csproj
+++ b/http/http.csproj
@@ -1,8 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Azure.Functions.Sdk/0.5.0">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>beb2e7ae-090e-4ec9-918a-84797f600af9</UserSecretsId>
@@ -12,7 +10,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Migrate `http/http.csproj` to `Azure.Functions.Sdk/1.0.0`.
- Remove the SDK-provided `AzureFunctionsVersion` and `OutputType` properties.
- Remove `Microsoft.Azure.Functions.Worker.Sdk` while retaining the explicit worker runtime reference.

## Motivation

This prepares the sample for the new Azure Functions MSBuild SDK model documented in https://github.com/MicrosoftDocs/azure-docs-pr/pull/319884.

> [!IMPORTANT]
> Merge this PR only after `Azure.Functions.Sdk/1.0.0` is published.

## Validation

- `dotnet build http/http.csproj`
- Build succeeded with 0 warnings and 0 errors using the functionally equivalent, currently available `Azure.Functions.Sdk/0.5.0` package and .NET SDK 10.0.111.